### PR TITLE
Added Convience (#43)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,16 @@
 
 import PackageDescription
 
+let swiftSettings: [SwiftSetting] = [
+  .enableUpcomingFeature("BareSlashRegexLiterals"),
+  .enableUpcomingFeature("ConciseMagicFile"),
+  .enableUpcomingFeature("ExistentialAny"),
+  .enableUpcomingFeature("ForwardTrailingClosures"),
+  .enableUpcomingFeature("ImplicitOpenExistentials"),
+  .enableUpcomingFeature("StrictConcurrency"),
+  .unsafeFlags(["-warn-concurrency", "-enable-actor-data-race-checks"]),
+]
+
 let package = Package(
   name: "HTTPRequestable",
   defaultLocalization: "en",

--- a/Sources/HTTPRequestable/Extensions/HTTPField+Common.swift
+++ b/Sources/HTTPRequestable/Extensions/HTTPField+Common.swift
@@ -52,12 +52,4 @@ public extension HTTPField {
   static var defaultUserAgent: Self {
     .userAgent(String.url_userAgent)
   }
-
-  static var defaultAcceptLanguage: Self {
-    .acceptLanguage(Locale.preferredLanguages.prefix(6).url_qualityEncoded())
-  }
-
-  static var defaultAcceptEncoding: Self {
-    .acceptEncoding(["br", "gzip", "deflate"].url_qualityEncoded())
-  }
 }

--- a/Sources/HTTPRequestable/Extensions/String+OSName.swift
+++ b/Sources/HTTPRequestable/Extensions/String+OSName.swift
@@ -8,7 +8,9 @@ import Foundation
 
 extension String {
   static var url_osName: String {
-    #if os(iOS)
+    #if targetEnvironment(simulator)
+    return "iOS(Simulator)"
+    #elseif os(iOS)
     #if targetEnvironment(macCatalyst)
     return "macOS(Catalyst)"
     #else
@@ -20,6 +22,8 @@ extension String {
     return "tvOS"
     #elseif os(macOS)
     return "macOS"
+    #elseif os(visionOS)
+    return "visionOS"
     #else
     return "Unknown"
     #endif

--- a/Sources/HTTPRequestable/Extensions/URLRequest+Builder.swift
+++ b/Sources/HTTPRequestable/Extensions/URLRequest+Builder.swift
@@ -43,7 +43,9 @@ public extension URLRequest {
       request.setValue(contentType, forHTTPField: .contentType)
     }
     request.httpBody = httpBody
-    request.setValue("\(httpBody?.count ?? 0)", forHTTPField: .contentLength)
+    if httpBody != nil {
+      request.setValue("\(httpBody?.count ?? 0)", forHTTPField: .contentLength)
+    }
     return request
   }
 
@@ -161,21 +163,31 @@ public extension URLRequest {
 
 public extension URLRequest {
   @discardableResult
+  @inline(__always)
   func setContentType(_ contentType: String) -> Self {
     setHeader(.contentType(contentType))
   }
 
   @discardableResult
+  @inline(__always)
   func setContentType(_ contentType: HTTPContentType) -> Self {
     setHeader(.contentType(contentType))
   }
 
   @discardableResult
+  @inline(__always)
+  func setHttpBody(_ httpBody: Data?, contentType: HTTPContentType? = nil) -> Self {
+    setHttpBody(httpBody, contentType: contentType?.rawValue)
+  }
+
+  @discardableResult
+  @inline(__always)
   func setUserAgent(_ userAgent: String) -> Self {
     setHeader(.userAgent(userAgent))
   }
 
   @discardableResult
+  @inline(__always)
   func setMethod(_ method: HTTPMethod?) -> Self {
     setHttpMethod(method?.rawValue)
   }
@@ -199,6 +211,7 @@ public extension URLRequest {
   }
 
   @discardableResult
+  @inline(__always)
   func addHeader(_ header: HTTPField) -> Self {
     addHttpHeader(header.value, forField: header.name)
   }

--- a/Tests/HTTPRequestableTests/MultiformDataTests.swift
+++ b/Tests/HTTPRequestableTests/MultiformDataTests.swift
@@ -24,7 +24,7 @@ final class MultiformDataTests: XCTestCase {
     XCTAssertEqual(multipartData.finalBoundary, finalBoundary)
     XCTAssertEqual(multipartData.finalBoundaryData, Data(finalBoundary.utf8))
   }
-  
+
   func testOneItem() throws {
     let boundary = "109AF0987D004171B0A8481D6401B62D"
     let profileDataString = "{\"familyName\": \"Malik\", \"givenName\": \"Waqar\"}"


### PR DESCRIPTION
* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Update the HTTPTypes dependency (#21) (#22)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Latest Packages

* Moved Mltipart to its own package

* Updated Package Requirement

* Updated the URLRequestable

* Added HTTPTranferable

* Moved the test to HTTPRequestable

* Merged requetable

* Fixed spacing

* Added Missing default property

* Fixed the test results

* made the query items set

* Fixed the protocol methods

* Fixed the test

* Added the query items writable

* reverted the change

* formatting

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Updated to the latest Dependencies

* Removed the linter becase MessageKit conflicts with Linter

* Remvoe linter

* Git Ignore

* Added ignore update

* Updated documentation

* Updated the swiftversion and formatted

* Fixed the formatting and .gitignore

* Fixed the spelling (#27)

* Latest Results (#28) (#29)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Update the HTTPTypes dependency (#21) (#22)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Latest Packages

* Moved Mltipart to its own package

* Updated Package Requirement

* Updated the URLRequestable

* Added HTTPTranferable

* Moved the test to HTTPRequestable

* Merged requetable

* Fixed spacing

* Added Missing default property

* Fixed the test results

* made the query items set

* Fixed the protocol methods

* Fixed the test

* Added the query items writable

* reverted the change

* formatting

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Updated to the latest Dependencies

* Removed the linter becase MessageKit conflicts with Linter

* Remvoe linter

* Git Ignore

* Added ignore update

* Updated documentation

* Updated the swiftversion and formatted

* Fixed the formatting and .gitignore

* Fixed the spelling (#27)

* Unified the transformer (#31)

* Unified the request builder (#33)

* Updated the Package depencey and gitignore

* Unified the protocols

* Fixed the field settings

* HTTPURLResponse conversion

* Removed the localied macro

* Latest Changes (#34) (#35)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Update the HTTPTypes dependency (#21) (#22)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Latest Packages

* Moved Mltipart to its own package

* Updated Package Requirement

* Updated the URLRequestable

* Added HTTPTranferable

* Moved the test to HTTPRequestable

* Merged requetable

* Fixed spacing

* Added Missing default property

* Fixed the test results

* made the query items set

* Fixed the protocol methods

* Fixed the test

* Added the query items writable

* reverted the change

* formatting

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Updated to the latest Dependencies

* Removed the linter becase MessageKit conflicts with Linter

* Remvoe linter

* Git Ignore

* Added ignore update

* Updated documentation

* Updated the swiftversion and formatted

* Fixed the formatting and .gitignore

* Fixed the spelling (#27)

* Latest Results (#28) (#29)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Update the HTTPTypes dependency (#21) (#22)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Latest Packages

* Moved Mltipart to its own package

* Updated Package Requirement

* Updated the URLRequestable

* Added HTTPTranferable

* Moved the test to HTTPRequestable

* Merged requetable

* Fixed spacing

* Added Missing default property

* Fixed the test results

* made the query items set

* Fixed the protocol methods

* Fixed the test

* Added the query items writable

* reverted the change

* formatting

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Updated to the latest Dependencies

* Removed the linter becase MessageKit conflicts with Linter

* Remvoe linter

* Git Ignore

* Added ignore update

* Updated documentation

* Updated the swiftversion and formatted

* Fixed the formatting and .gitignore

* Fixed the spelling (#27)

* Unified the transformer (#31)

* Unified the request builder (#33)

* Updated the Package depencey and gitignore

* Unified the protocols

* Fixed the field settings

* HTTPURLResponse conversion

* Removed the localied macro

* Renamed the Package (#36)

* Updated the Multipart construction (#38)

* Added support swift 6

* Added MultipartForm

* Collection Conformance

* Converted the Content Type to struct

* Properlly enode body parts

* Fixed the Multipart Form

* Updated the MimeType of image

* Added convience to set content type (#42)